### PR TITLE
Fix possible typo in androidFilePwd command and keep typo version for compatibility

### DIFF
--- a/agent/src/rpc/android.ts
+++ b/agent/src/rpc/android.ts
@@ -19,6 +19,7 @@ export const android = {
   androidShellExec: (cmd: string): Promise<IExecutedCommand> => androidshell.execute(cmd),
 
   // android filesystem
+  androidFilePwd: () => androidfilesystem.pwd(),
   androidFileCwd: () => androidfilesystem.pwd(),
   androidFileDelete: (path: string) => androidfilesystem.deleteFile(path),
   androidFileDownload: (path: string) => androidfilesystem.readFile(path),


### PR DESCRIPTION
the rpc call androidFileCwd should be called andoidFilePwd, since it also calls the pwd function!?